### PR TITLE
Allows for empty config objects in the resource convenience methods.

### DIFF
--- a/lib/httpi.js
+++ b/lib/httpi.js
@@ -211,7 +211,8 @@
 
 
 				// I execute a DELETE request and return the http promise.
-				delete: function( config ) {
+				delete: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "delete";
@@ -223,7 +224,8 @@
 
 
 				// I execute a GET request and return the http promise.
-				get: function( config ) {
+				get: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "get";
@@ -235,7 +237,8 @@
 
 
 				// I execute a HEAD request and return the http promise.
-				head: function( config ) {
+				head: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "head";
@@ -247,7 +250,8 @@
 
 
 				// I execute a JSONP request and return the http promise.
-				jsonp: function( config ) {
+				jsonp: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "jsonp";
@@ -308,7 +312,8 @@
 
 
 				// I execute a POST request and return the http promise.
-				post: function( config ) {
+				post: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "post";
@@ -320,7 +325,8 @@
 
 
 				// I execute a PUT request and return the http promise.
-				put: function( config ) {
+				put: function( c ) {
+					var config = c || {};
 
 					// Inject resource-related properties.
 					config.method = "put";


### PR DESCRIPTION
This gives the user the option of just calling resource.get() instead of having to explicitly state resource.get({}).
