### PR TITLE
Fix 0 param interpolation

### DIFF
--- a/lib/httpi.js
+++ b/lib/httpi.js
@@ -113,7 +113,13 @@
 					function( $0, label ) {
 
 						// NOTE: Giving "data" precedence over "params".
-						return( popFirstKey( data, params, label ) || "" );
+						var val = popFirstKey(data, params, label);
+
+						if (val === null || val === undefined) {
+						    return '';
+						}
+
+						return( val );
 
 					}
 				);


### PR DESCRIPTION
There is a little bug in the parameter interpolation, when we want to use `0` as parameter:
E.g:

```
var resource = httpi.resource( "api/friends/:id" );
var promise = resource.get({
    params: {
        id: 0
    }
});
```

In this case, the interpolation gives incorrect result (`api/friends`), because `0` in JS is falsy.
It is not really common, to use zero as parameter, but it happens once in a while. 
